### PR TITLE
Adding closest method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea

--- a/domassist.default.js
+++ b/domassist.default.js
@@ -11,6 +11,7 @@ import once from './lib/once';
 import removeClass from './lib/removeClass';
 import show from './lib/show';
 import matches from './lib/matches';
+import closest from './lib/closest';
 
 export default {
   addClass,
@@ -25,5 +26,6 @@ export default {
   once,
   removeClass,
   show,
-  matches
+  matches,
+  closest
 };

--- a/domassist.js
+++ b/domassist.js
@@ -11,4 +11,5 @@ export { default as once } from './lib/once';
 export { default as removeClass } from './lib/removeClass';
 export { default as show } from './lib/show';
 export { default as matches } from './lib/matches';
+export { default as closest } from './lib/closest';
 export { default } from './domassist.default';

--- a/lib/closest.js
+++ b/lib/closest.js
@@ -1,0 +1,11 @@
+import matches from './matches';
+
+function closest(el, selector) {
+  let parent = el.parentElement;
+  while (parent.parentElement && !matches(parent, selector)) {
+    parent = parent.parentElement;
+  }
+  return (matches(parent, selector)) ? parent : null;
+}
+
+export default closest;

--- a/lib/matches.js
+++ b/lib/matches.js
@@ -18,7 +18,7 @@ function matches(el, selector) {
   });
 
   if (match) {
-    return match.call(el, selector);
+    return (el) ? match.call(el, selector) : null;
   }
 }
 

--- a/test/domassist.test.js
+++ b/test/domassist.test.js
@@ -76,6 +76,37 @@ test('matches', assert => {
   assert.end();
 });
 
+test('closest', assert => {
+  const el = domassist.findOne('#domassist');
+  const levels = 4;
+  // clean up test dom
+  while (el.firstChild) {
+    el.removeChild(el.firstChild);
+  }
+  function addNode(num) {
+    const node = document.createElement('div');
+    node.innerText = num;
+    node.classList.add(`level-${num}`);
+    const children = el.children;
+    if (children.length) {
+      const child = domassist.findOne(`.level-${num - 1}`);
+      child.appendChild(node);
+    } else {
+      el.appendChild(node);
+    }
+  }
+  for (let i = 0; i < levels; i += 1) {
+    addNode(i + 1);
+  }
+  const startEl = domassist.findOne(`.level-${levels}`);
+  let count = levels - 1;
+  while (count) {
+    assert.ok(domassist.closest(startEl, `.level-${count}`), `Should find element with class of level-${count}`);
+    --count;
+  }
+  assert.end();
+});
+
 test('Events - on', assert => {
   const el = domassist.findOne('#domassist');
 


### PR DESCRIPTION
I went with `closest` instead of `parent` since it's purpose is to traverse the DOM looking for a matching selector. It matches what the native `closest()` DOM method does.

I also made a slight change to `matches()`. I check if the passed in element is `null`. This is because when traversing the DOM once you get the top `null` gets returned when getting the `parentElement`.