### PR TITLE
Add ready() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea

--- a/domassist.default.js
+++ b/domassist.default.js
@@ -11,6 +11,7 @@ import once from './lib/once';
 import removeClass from './lib/removeClass';
 import show from './lib/show';
 import matches from './lib/matches';
+import ready from './lib/ready';
 
 export default {
   addClass,
@@ -25,5 +26,6 @@ export default {
   once,
   removeClass,
   show,
-  matches
+  matches,
+  ready
 };

--- a/domassist.js
+++ b/domassist.js
@@ -11,4 +11,5 @@ export { default as once } from './lib/once';
 export { default as removeClass } from './lib/removeClass';
 export { default as show } from './lib/show';
 export { default as matches } from './lib/matches';
+export { default as ready } from './lib/ready';
 export { default } from './domassist.default';

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -1,0 +1,23 @@
+const setupReady = (callbacks) => (callback) => {
+  callbacks.push(callback);
+  function execute() {
+    while (callbacks.length) {
+      const fn = callbacks.shift();
+      if (typeof fn === 'function') {
+        fn();
+      }
+    }
+  }
+  function loaded() {
+    document.removeEventListener('DOMContentLoaded', loaded);
+    execute();
+  }
+
+  if (document.readyState === 'complete') {
+    return execute();
+  }
+  document.addEventListener('DOMContentLoaded', loaded);
+};
+const ready = setupReady([]);
+
+export default ready;

--- a/test/domassist.test.js
+++ b/test/domassist.test.js
@@ -14,6 +14,26 @@ init();
 
 const page = window.phantom.page;
 
+test('ready', assert => {
+  // if you add more assertions update this number
+  const assertions = 3;
+
+  assert.plan(assertions);
+
+  domassist.ready(() => {
+    const x = 1;
+    assert.ok(x === 1, '1st ready() fired');
+  });
+  domassist.ready(() => {
+    const x = 2;
+    assert.ok(x === 2, '2nd ready() fired');
+  });
+  domassist.ready(() => {
+    const x = 3;
+    assert.ok(x === 3, '3rd ready() fired');
+  });
+});
+
 test('find, findOne', assert => {
   const el = domassist.findOne('#domassist');
 


### PR DESCRIPTION
You can add as many `ready()` calls as you like. I added a check to make sure a function is passed. If anything else is passed it just gets ignored.

I couldn't figure out how to test that the functions were being queued up before the `DOMContentLoaded` event. Right now the test is showing that the functions are fired even though the `DOMContentLoaded` event has already happened.